### PR TITLE
DB schema proposal

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,9 +1,3 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
-// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
-// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
-
 generator client {
   provider = "prisma-client-js"
 }
@@ -20,47 +14,69 @@ enum Role {
 }
 
 model User {
-  id         String    @id @default(uuid()) @db.Uuid
-  email      String    @unique
-  name       String?
-  role       Role      @default(USER)
-  created_at DateTime  @default(now()) @db.Timestamp(6)
-  updated_at DateTime? @updatedAt @db.Timestamp(6)
-  persons    Person[]
+  id             String    @id @default(uuid()) @db.Uuid
+  email          String    @unique
+  name           String?
+  role           Role      @default(USER)
+  is_blacklisted Boolean   @default(false)
+  created_at     DateTime  @default(now()) @db.Timestamp(6)
+  updated_at     DateTime? @updatedAt @db.Timestamp(6)
+  persons        Person[]
 
   @@map("users")
 }
 
+model Vendor {
+  id             String    @id @default(uuid()) @db.Uuid
+  name           String
+  url            String?
+  is_blacklisted Boolean   @default(false)
+  created_at     DateTime  @default(now()) @db.Timestamp(6)
+  updated_at     DateTime? @updatedAt @db.Timestamp(6)
+  persons        Person[]
+
+  @@map("vendors")
+}
+
 model Person {
-  first_name             String    @db.VarChar(255)
-  first_name_normalized  String?   @db.VarChar(255)
-  last_name              String    @db.VarChar(255)
-  last_name_normalized   String?   @db.VarChar(255)
-  middle_name            String?   @db.VarChar(255)
-  middle_name_normalized String?   @db.VarChar(255)
-  birth_date             String    @db.VarChar(255)
-  birth_date_normalized  DateTime?
-  record_id              String    @db.Uuid
-  record_date            String    @db.VarChar(255)
-  record_date_normalized DateTime?
-  birth_place            String    @db.VarChar(255)
-  birth_place_lat        Float
-  birth_place_lon        Float
-  record_place           String    @db.VarChar(255)
-  record_place_lat       Float?
-  record_place_lon       Float?
-  record_type            String    @db.VarChar(255)
-  record_type_normalized String?   @db.VarChar(255)
-  archive                String    @db.VarChar(255)
-  fund                   String    @db.VarChar(255)
-  description            String    @db.VarChar(255)
-  case                   String    @db.VarChar(255)
-  page                   String?   @db.VarChar(255)
+  first_name             String    @db.VarChar(255) // "іоанн"
+  first_name_normalized  String?   @db.VarChar(255) // "іван"
+  last_name              String    @db.VarChar(255) // "мельник"
+  last_name_normalized   String?   @db.VarChar(255) // "мельник"
+  middle_name            String?   @db.VarChar(255) // "іоанов"
+  middle_name_normalized String?   @db.VarChar(255) // "іванович"
+  birth_date             String    @db.VarChar(255) // "1900"
+  is_birth_date_approx   Boolean   @default(false) // true
+  birth_date_normalized  DateTime? // "1900-01-01T00:00:00.000Z"
+  birth_place            String?   @db.VarChar(255) // Полонне, Полонський повіт, Волинська губернія, Російська імперія
+  birth_place_lat        Float? // 51.1989
+  birth_place_lon        Float? // 24.6093
+  record_id              String    @db.Uuid // "123e4567-e89b-12d3-a456-426614174000"
+  record_date            String    @db.VarChar(255) // "1914-01-01"
+  is_record_date_approx  Boolean   @default(false) // false
+  record_date_normalized DateTime? // "1914-01-01T00:00:00.000Z"
+  record_place           String?   @db.VarChar(255) // Полонне, Полонський повіт, Волинська губернія, Російська імперія
+  record_place_lat       Float? // 51.1989
+  record_place_lon       Float? // 24.6093
+  record_type            String    @db.VarChar(255) // весілля
+  record_type_normalized String?   @db.VarChar(255) // весілля
+  archive                String    @db.VarChar(255) // ДАДнО
+  fund                   String    @db.VarChar(255) // 193
+  description            String    @db.VarChar(255) // 1
+  case                   String    @db.VarChar(255) // 555
+  page                   String?   @db.VarChar(255) // 10 - номер сторінки вказаний на документі
+  note                   String?   @db.VarChar(255) // примітка
   created_at             DateTime  @default(now()) @db.Timestamp(6)
   updated_at             DateTime? @updatedAt @db.Timestamp(6)
   author_id              String    @db.Uuid
   author                 User      @relation(fields: [author_id], references: [id])
+  vendor_id              String    @db.Uuid
+  vendor                 Vendor    @relation(fields: [vendor_id], references: [id])
 
-  @@unique([first_name, last_name, birth_date, record_id, author_id])
+  // CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  @@unique([first_name, last_name, record_id, author_id, vendor_id], name: "unique_person")
+  @@index([first_name(ops: raw("gin_trgm_ops"))], type: Gin, name: "first_name_gin_trgm_ops_idx")
+  @@index([last_name(ops: raw("gin_trgm_ops"))], type: Gin, name: "last_name_gin_trgm_ops_idx")
+  @@index([middle_name(ops: raw("gin_trgm_ops"))], type: Gin, name: "middle_name_gin_trgm_ops_idx")
   @@map("persons")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,8 +43,9 @@ model Person {
   first_name_normalized  String?   @db.VarChar(255) // "іван"
   last_name              String    @db.VarChar(255) // "мельник"
   last_name_normalized   String?   @db.VarChar(255) // "мельник"
-  middle_name            String?   @db.VarChar(255) // "іоанов"
-  middle_name_normalized String?   @db.VarChar(255) // "іванович"
+  middle_name            String?   @db.VarChar(255) // "стефанов"
+  father_name_normalized String?   @db.VarChar(255) // "степан"
+  is_male                Boolean?  // true – на основі нормалізованого імені
   birth_date             String    @db.VarChar(255) // "1900"
   is_birth_date_approx   Boolean   @default(false) // true
   birth_date_normalized  DateTime? // "1900-01-01T00:00:00.000Z"
@@ -79,4 +80,12 @@ model Person {
   @@index([last_name(ops: raw("gin_trgm_ops"))], type: Gin, name: "last_name_gin_trgm_ops_idx")
   @@index([middle_name(ops: raw("gin_trgm_ops"))], type: Gin, name: "middle_name_gin_trgm_ops_idx")
   @@map("persons")
+}
+
+model FirstName {
+  name            String @unique
+  normalized_name String
+  is_male         Boolean
+
+  @@map("first_names")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,7 +26,7 @@ model User {
   @@map("users")
 }
 
-model Vendor {
+model Resource {
   id             String    @id @default(uuid()) @db.Uuid
   name           String
   url            String?
@@ -35,7 +35,7 @@ model Vendor {
   updated_at     DateTime? @updatedAt @db.Timestamp(6)
   persons        Person[]
 
-  @@map("vendors")
+  @@map("resources")
 }
 
 model Person {
@@ -70,11 +70,11 @@ model Person {
   updated_at             DateTime? @updatedAt @db.Timestamp(6)
   author_id              String    @db.Uuid
   author                 User      @relation(fields: [author_id], references: [id])
-  vendor_id              String    @db.Uuid
-  vendor                 Vendor    @relation(fields: [vendor_id], references: [id])
+  resource_id            String    @db.Uuid
+  resource               Resource  @relation(fields: [resource_id], references: [id])
 
   // CREATE EXTENSION IF NOT EXISTS pg_trgm;
-  @@unique([first_name, last_name, record_id, author_id, vendor_id], name: "unique_person")
+  @@unique([first_name, last_name, record_id, author_id, resource_id], name: "unique_person")
   @@index([first_name(ops: raw("gin_trgm_ops"))], type: Gin, name: "first_name_gin_trgm_ops_idx")
   @@index([last_name(ops: raw("gin_trgm_ops"))], type: Gin, name: "last_name_gin_trgm_ops_idx")
   @@index([middle_name(ops: raw("gin_trgm_ops"))], type: Gin, name: "middle_name_gin_trgm_ops_idx")


### PR DESCRIPTION
1. single _persons_ table for all indexes
    - single index for everything
    - faster user search query execution, in compare to searching in every table one-by-one
    - raw and normalized data are in columns of same table
2. use table partition by vendor_id, for search query optimization (need to manually write in raw prisma migration)
3. _users_ table to manage users :saluting_face: 
4. _resources_ table shouldn't be joined in default search query, to improve performance, and will be used only to render list of filters in search form

![image](https://github.com/user-attachments/assets/8e27009f-7f8d-4290-86ae-e8552d2110c0)